### PR TITLE
feat: migrate default kubernetes to 1.29

### DIFF
--- a/eks/addons.tf
+++ b/eks/addons.tf
@@ -1,5 +1,6 @@
 module "eks_blueprints_addons" {
-  source = "aws-ia/eks-blueprints-addons/aws"
+  source  = "aws-ia/eks-blueprints-addons/aws"
+  version = "~> 1.16.2"
 
   depends_on = [module.eks]
 
@@ -47,4 +48,19 @@ resource "kubernetes_storage_class" "gp3-encrypted" {
   reclaim_policy         = "Delete"
   volume_binding_mode    = "WaitForFirstConsumer"
   allow_volume_expansion = true
+}
+
+resource "kubernetes_annotations" "disable_gp2" {
+  depends_on = [module.eks_blueprints_addons]
+  annotations = {
+    "storageclass.kubernetes.io/is-default-class" : "false"
+  }
+
+  api_version = "storage.k8s.io/v1"
+  kind        = "StorageClass"
+  metadata {
+    name = "gp2"
+  }
+
+  force = true
 }

--- a/eks/main.tf
+++ b/eks/main.tf
@@ -16,7 +16,7 @@ locals {
 
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "20.8.4"
+  version = "~> 20.8.4"
 
   cluster_name    = var.cluster_name
   cluster_version = var.cluster_version

--- a/eks/variables.tf
+++ b/eks/variables.tf
@@ -70,13 +70,13 @@ variable "cluster_name" {
 variable "cluster_version" {
   description = "Version of the cluster"
   type        = string
-  default     = "1.28"
+  default     = "1.29"
 }
 
 variable "autoscaler_version" {
   description = "Autoscaler version"
   type        = string
-  default     = "1.28.4"
+  default     = "1.29.2"
 }
 
 variable "node_pools_config" {

--- a/eks/vpc.tf
+++ b/eks/vpc.tf
@@ -7,7 +7,8 @@
 # Creates a series of public subnets within the VPC based on the var.subnets input variable,
 # which contains details like CIDR blocks and availability zones.
 module "vpc" {
-  source = "terraform-aws-modules/vpc/aws"
+  source  = "terraform-aws-modules/vpc/aws"
+  version = "~> 5.8.1"
 
   name = "${var.cluster_name}-vpc"
   cidr = var.cidr

--- a/variables.tf
+++ b/variables.tf
@@ -80,13 +80,13 @@ variable "eks_cluster_name" {
 variable "eks_cluster_version" {
   description = "Version of the cluster"
   type        = string
-  default     = "1.28"
+  default     = "1.29"
 }
 
 variable "eks_autoscaler_version" {
   description = "Version of AWS Autoscaler"
   type        = string
-  default     = "1.28.4"
+  default     = "1.29.2"
 }
 
 variable "eks_tags" {


### PR DESCRIPTION
- update kubernetes to 1.29
- fix aws modules versions
- disable default gp2 storage class

Resolves #12 