### PR TITLE
Provider in module conflicting with local provider

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,7 +1,3 @@
-provider "aws" {
-  region = var.eks_region
-}
-
 provider "kubernetes" {
   host                   = module.eks_aws.cluster_endpoint
   cluster_ca_certificate = base64decode(module.eks_aws.cluster_certificate_authority)


### PR DESCRIPTION
**Description**
While building module using example, encountered issue where provider wouldn't work

**Type of change**
Removing provider 
**How Has This Been Tested?**
Successful plan built after removal

What is the current behavior?
```
Planning failed. Terraform encountered an error while generating this plan.
╷
│ Error: No valid credential sources found
│
│   with module.eks_clickhouse.provider["registry.terraform.io/hashicorp/aws"],
│   on .terraform/modules/eks_clickhouse/main.tf line 1, in provider "aws":
│    1: provider "aws" {
│
│ Please see https://registry.terraform.io/providers/hashicorp/aws
│ for more information about providing credentials.
│
│ Error: failed to refresh cached credentials, no EC2 IMDS role found, operation error ec2imds: GetMetadata, exceeded maximum number of attempts, 3, request send failed, Get "http://169.254.169.254/latest/meta-data/iam/security-credentials/": dial tcp 169.254.169.254:80: connect: host is down
│
╵

```

What is the expected behavior?
Plan building without issue

What is the motivation / use case for changing the behavior?
To enable the user to use their own provider
