### PR TITLE
AWS-cli exe feature to allow aws profiles to be used dynamically.

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,6 @@ provider "aws" {
 module "eks_clickhouse" {
   source  = "github.com/Altinity/terraform-aws-eks-clickhouse"
 
-  aws_profile = "sandbox"
   install_clickhouse_operator = true
   install_clickhouse_cluster  = true
 

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ provider "aws" {
 module "eks_clickhouse" {
   source  = "github.com/Altinity/terraform-aws-eks-clickhouse"
 
+  aws_profile = "sandbox"
   install_clickhouse_operator = true
   install_clickhouse_cluster  = true
 

--- a/main.tf
+++ b/main.tf
@@ -1,7 +1,3 @@
-provider "aws" {
-  region = var.eks_region
-}
-
 provider "kubernetes" {
   host                   = module.eks_aws.cluster_endpoint
   cluster_ca_certificate = base64decode(module.eks_aws.cluster_certificate_authority)

--- a/main.tf
+++ b/main.tf
@@ -1,10 +1,14 @@
+locals {
+  eks_get_token_args = var.aws_profile != null ? ["eks", "get-token", "--cluster-name", var.eks_cluster_name, "--region", var.eks_region, "--profile", var.aws_profile] : ["eks", "get-token", "--cluster-name", var.eks_cluster_name, "--region", var.eks_region]
+}
+
 provider "kubernetes" {
   host                   = module.eks_aws.cluster_endpoint
   cluster_ca_certificate = base64decode(module.eks_aws.cluster_certificate_authority)
 
   exec {
     api_version = "client.authentication.k8s.io/v1beta1"
-    args        = ["eks", "get-token", "--cluster-name", var.eks_cluster_name, "--region", var.eks_region]
+    args        = local.eks_get_token_args
     command     = "aws"
   }
 }
@@ -15,7 +19,7 @@ provider "helm" {
     cluster_ca_certificate = base64decode(module.eks_aws.cluster_certificate_authority)
     exec {
       api_version = "client.authentication.k8s.io/v1beta1"
-      args        = ["eks", "get-token", "--cluster-name", var.eks_cluster_name, "--region", var.eks_region]
+      args        = local.eks_get_token_args
       command     = "aws"
     }
   }

--- a/variables.tf
+++ b/variables.tf
@@ -13,6 +13,12 @@ variable "install_clickhouse_operator" {
   default     = true
 }
 
+variable "aws_profile" {
+  description = "AWS profile of deployed cluster."
+  type        = string
+  default     = "null"
+}
+
 ################################################################################
 # ClickHouse Operator
 ################################################################################


### PR DESCRIPTION
### Description
Allow users to execute the Terraform which contains executable aws-cli commands with a specified profile.

currently the profile has to be configurerd via `aws configure` but profiles are not considered. 

new change allows for SSO profiles and non-profiles

### Type of change
Added local with turnery that allows a profile to be defined if variable != null

```hcl

locals {
  eks_get_token_args = var.aws_profile != null ? ["eks", "get-token", "--cluster-name", var.eks_cluster_name, "--region", var.eks_region, "--profile", var.aws_profile] : ["eks", "get-token", "--cluster-name", var.eks_cluster_name, "--region", var.eks_region]
}

provider "kubernetes" {
  host                   = module.eks_aws.cluster_endpoint
  cluster_ca_certificate = base64decode(module.eks_aws.cluster_certificate_authority)

  exec {
    api_version = "client.authentication.k8s.io/v1beta1"
    args        = local.eks_get_token_args
    command     = "aws"
  }
}

provider "helm" {
  kubernetes {
    host                   = module.eks_aws.cluster_endpoint
    cluster_ca_certificate = base64decode(module.eks_aws.cluster_certificate_authority)
    exec {
      api_version = "client.authentication.k8s.io/v1beta1"
      args        = local.eks_get_token_args
      command     = "aws"
    }
  }
}

```
### How Has This Been Tested?
- Clean Plan
- Clean Apply

Tested and built with and without profile.

### What is the current behavior?
Fails to get token and update kubectl config due to no valid credentials if sso or profile is not configured as default. 

```hcl

╷
│ Error: Kubernetes cluster unreachable: Get "https://3D433301BAE644EEAF38A8F6BA676794.gr7.eu-central-1.eks.amazonaws.com/version": getting credentials: exec: executable aws failed with exit code 253
│
│   with module.eks_clickhouse.module.eks_aws.module.eks_blueprints_addons.module.cluster_autoscaler.helm_release.this[0],
│   on .terraform/modules/eks_clickhouse.eks_aws.eks_blueprints_addons.cluster_autoscaler/main.tf line 9, in resource "helm_release" "this":
│    9: resource "helm_release" "this" {
│
╵

```

### What is the expected behavior?
Allowance of Dynamic token grab and updating kubetcl config to allow easy connection to pods

### What is the motivation / use case for changing the behavior?
To allow profiles (SSO/non-SSO) to be used to avoid having to manually change local setup. 

