### PR TITLE
feat: add new node pools variable setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ module "eks_clickhouse" {
     }
 
     disk_size      = 20
-    instance_types = ["m5.large"]
+    instance_types = ["m6i.large"]
   }
 
   eks_tags = {

--- a/README.md
+++ b/README.md
@@ -61,16 +61,25 @@ module "eks_clickhouse" {
     "10.0.102.0/24",
     "10.0.103.0/24"
   ]
-  eks_node_pools_config = {
-    scaling_config = {
-      desired_size = 2
-      max_size     = 10
-      min_size     = 0
-    }
 
-    disk_size      = 20
-    instance_types = ["m6i.large"]
-  }
+  eks_node_pools = [
+    {
+      name          = "clickhouse"
+      instance_type = "m6i.large"
+      desired_size  = 0
+      max_size      = 10
+      min_size      = 0
+      zones         = ["us-east-1a", "us-east-1b", "us-east-1c"]
+    },
+    {
+      name          = "system"
+      instance_type = "t3.large"
+      desired_size  = 1
+      max_size      = 10
+      min_size      = 0
+      zones         = ["us-east-1a"]
+    }
+  ]
 
   eks_tags = {
     CreatedBy = "mr-robot"

--- a/docs/README.md
+++ b/docs/README.md
@@ -90,7 +90,7 @@ module "eks_clickhouse" {
     }
 
     disk_size      = 20
-    instance_types = ["m5.large"]
+    instance_types = ["m6i.large"]
   }
 
   eks_tags = {

--- a/docs/README.md
+++ b/docs/README.md
@@ -82,16 +82,24 @@ module "eks_clickhouse" {
     "10.0.102.0/24",
     "10.0.103.0/24"
   ]
-  eks_node_pools_config = {
-    scaling_config = {
-      desired_size = 2
-      max_size     = 10
-      min_size     = 0
+  eks_node_pools = [
+    {
+      name          = "clickhouse"
+      instance_type = "m6i.large"
+      desired_size  = 0
+      max_size      = 10
+      min_size      = 0
+      zones         = ["us-east-1a", "us-east-1b", "us-east-1c"]
+    },
+    {
+      name          = "system"
+      instance_type = "t3.large"
+      desired_size  = 1
+      max_size      = 10
+      min_size      = 0
+      zones         = ["us-east-1a"]
     }
-
-    disk_size      = 20
-    instance_types = ["m6i.large"]
-  }
+  ]
 
   eks_tags = {
     CreatedBy = "mr-robot"

--- a/eks/addons.tf
+++ b/eks/addons.tf
@@ -19,10 +19,11 @@ module "eks_blueprints_addons" {
   cluster_autoscaler = {
     timeout = "300"
     values = [templatefile("${path.module}/helm/cluster-autoscaler.yaml.tpl", {
-      aws_region         = var.region,
-      eks_cluster_id     = var.cluster_name,
-      autoscaler_version = "v${var.autoscaler_version}",
-      role_arn           = aws_iam_role.cluster_autoscaler.arn
+      aws_region          = var.region,
+      eks_cluster_id      = var.cluster_name,
+      autoscaler_version  = "v${var.autoscaler_version}",
+      autoscaler_replicas = var.autoscaler_replicas,
+      role_arn            = aws_iam_role.cluster_autoscaler.arn
     })]
   }
 }

--- a/eks/helm/cluster-autoscaler.yaml.tpl
+++ b/eks/helm/cluster-autoscaler.yaml.tpl
@@ -18,17 +18,18 @@ rbac:
   create: true
 
 extraArgs:
-  logtostderr: "true"
+  logtostderr: true
   stderrthreshold: info
   v: 4
-  balance-similar-node-groups: "true"
-  skip-nodes-with-local-storage: "false"
-  skip-nodes-with-system-pods: "false"
+  balance-similar-node-groups: true
+  skip-nodes-with-local-storage: false
+  skip-nodes-with-system-pods: false
+  expander: most-pods
 
 image:
   tag: ${autoscaler_version}
 
-replicaCount: 1
+replicaCount: ${autoscaler_replicas}
 
 resources:
   limits:

--- a/eks/main.tf
+++ b/eks/main.tf
@@ -1,17 +1,43 @@
 locals {
   account_id = data.aws_caller_identity.current.account_id
 
-  subnets = var.enable_nat_gateway ? module.vpc.private_subnets : module.vpc.public_subnets
+  zones           = { for k, v in data.aws_subnet.subnets : k => v.availability_zone }
+  subnets_by_zone = { for id, subnet in data.aws_subnet.subnets : subnet.availability_zone => id }
+  subnets         = var.enable_nat_gateway ? module.vpc.private_subnets : module.vpc.public_subnets
 
-  # Generate all node pools possible combinations of subnets and instance types
-  node_pool_combinations = [for idx, np in flatten([
-    for subnet in local.subnets : [
-      for itype in var.node_pools_config.instance_types : {
-        subnet_id     = subnet
-        instance_type = itype
-      }
+  # Generate all node pools possible combinations of subnets and node pools
+  node_pool_combinations = flatten([
+    for np in var.node_pools : [
+      for zone in(np.zones != null ? np.zones : keys(local.subnets_by_zone)) : [
+        {
+          name          = np.name
+          subnet_id     = local.subnets_by_zone[zone]
+          instance_type = np.instance_type
+          labels        = np.labels
+          taints        = np.taints
+          ami_type      = np.ami_type
+          desired_size  = np.desired_size
+          max_size      = np.max_size
+          min_size      = np.min_size
+          disk_size     = np.disk_size
+        }
+      ]
     ]
-  ]) : np]
+  ])
+
+  node_pool_defaults = {
+    ami_type  = "AL2_x86_64"
+    disk_size = 20
+  }
+}
+
+data "aws_subnet" "subnets" {
+  for_each = toset(local.subnets)
+  id       = each.value
+}
+
+output "vpc" {
+  value = local.subnets_by_zone
 }
 
 module "eks" {
@@ -38,14 +64,13 @@ module "eks" {
     }
   }
 
-
   # Node Groups
   eks_managed_node_groups = { for idx, np in local.node_pool_combinations : "node-group-${tostring(idx)}" => {
-    desired_capacity = var.node_pools_config.scaling_config.desired_size
-    max_capacity     = var.node_pools_config.scaling_config.max_size
-    min_capacity     = var.node_pools_config.scaling_config.min_size
+    desired_size = np.desired_size
+    max_size     = np.max_size
+    min_size     = np.min_size
 
-    name            = "${var.cluster_name}-${tostring(idx)}"
+    name            = np.name
     use_name_prefix = true
 
     iam_role_use_name_prefix = false
@@ -54,10 +79,11 @@ module "eks" {
 
     instance_types = [np.instance_type]
     subnet_ids     = [np.subnet_id]
-    disk_size      = var.node_pools_config.disk_size
+    disk_size      = np.disk_size != null ? np.disk_size : local.node_pool_defaults.disk_size
+    ami_type       = np.ami_type != null ? np.ami_type : local.node_pool_defaults.ami_type
 
-    labels = var.node_pools_config.labels
-    taints = var.node_pools_config.taints
+    labels = np.labels
+    taints = np.taints
 
     tags = merge(
       var.tags,

--- a/eks/main.tf
+++ b/eks/main.tf
@@ -2,7 +2,7 @@ locals {
   account_id = data.aws_caller_identity.current.account_id
 
   subnets         = var.enable_nat_gateway ? module.vpc.private_subnets : module.vpc.public_subnets
-  subnets_by_zone = { for id, subnet in data.aws_subnet.subnets : subnet.availability_zone => id }
+  subnets_by_zone = { for _, subnet in data.aws_subnet.subnets : subnet.availability_zone => subnet.id }
 
   node_pool_defaults = {
     ami_type     = "AL2_x86_64"

--- a/eks/outputs.tf
+++ b/eks/outputs.tf
@@ -1,3 +1,7 @@
+output "cluster_node_pools" {
+  value = local.node_pool_combinations
+}
+
 output "cluster_arn" {
   value       = module.eks.cluster_arn
   description = "The Amazon Resource Name (ARN) of the cluster"

--- a/eks/variables.tf
+++ b/eks/variables.tf
@@ -79,15 +79,24 @@ variable "autoscaler_version" {
   default     = "1.29.2"
 }
 
-variable "node_pools_config" {
+variable "autoscaler_replicas" {
+  description = "Autoscaler replicas"
+  type        = number
+  default     = 1
+}
+
+variable "node_pools" {
   description = "Node pools configuration. The module will create a node pool for each combination of instance type and subnet. For example, if you have 3 subnets and 2 instance types, this module will create 6 different node pools."
 
-  type = object({
-    scaling_config = object({
-      desired_size = number
-      max_size     = number
-      min_size     = number
-    })
+  type = list(object({
+    name          = string
+    instance_type = string
+    ami_type      = optional(string)
+    disk_size     = optional(number)
+    desired_size  = number
+    max_size      = number
+    min_size      = number
+    zones         = optional(list(string))
 
     labels = optional(map(string))
     taints = optional(list(object({
@@ -95,24 +104,30 @@ variable "node_pools_config" {
       value  = string
       effect = string
     })), [])
+  }))
 
-    disk_size      = number
-    instance_types = list(string)
-  })
-
-  default = {
-    scaling_config = {
-      desired_size = 2
-      max_size     = 10
-      min_size     = 0
+  default = [
+    {
+      name          = "clickhouse"
+      instance_type = "m6i.large"
+      ami_type      = "AL2_x86_64"
+      desired_size  = 0
+      max_size      = 10
+      min_size      = 0
+      disk_size     = 20
+      zones         = ["us-east-1a", "us-east-1b", "us-east-1c"]
+    },
+    {
+      name          = "system"
+      instance_type = "t3.large"
+      ami_type      = "AL2_x86_64"
+      desired_size  = 1
+      max_size      = 10
+      min_size      = 0
+      disk_size     = 20
+      zones         = ["us-east-1a", "us-east-1b", "us-east-1c"]
     }
-
-    labels = {}
-    taints = []
-
-    disk_size      = 20
-    instance_types = ["m5.large"]
-  }
+  ]
 }
 
 variable "public_access_cidrs" {

--- a/eks/vpc.tf
+++ b/eks/vpc.tf
@@ -25,3 +25,11 @@ module "vpc" {
 
   tags = var.tags
 }
+
+output "private_subnets" {
+  value = module.vpc.private_subnets
+}
+
+output "public_subnets" {
+  value = module.vpc.public_subnets
+}

--- a/examples/default/main.tf
+++ b/examples/default/main.tf
@@ -43,7 +43,7 @@ module "eks_clickhouse" {
     }
 
     disk_size      = 20
-    instance_types = ["m5.large"]
+    instance_types = ["m6i.large"]
   }
 
   eks_tags = {

--- a/examples/default/main.tf
+++ b/examples/default/main.tf
@@ -35,16 +35,24 @@ module "eks_clickhouse" {
     "10.0.102.0/24",
     "10.0.103.0/24"
   ]
-  eks_node_pools_config = {
-    scaling_config = {
-      desired_size = 2
-      max_size     = 10
-      min_size     = 0
+  eks_node_pools = [
+    {
+      name          = "clickhouse"
+      instance_type = "m6i.large"
+      desired_size  = 0
+      max_size      = 10
+      min_size      = 0
+      zones         = ["us-east-1a", "us-east-1b", "us-east-1c"]
+    },
+    {
+      name          = "system"
+      instance_type = "t3.large"
+      desired_size  = 1
+      max_size      = 10
+      min_size      = 0
+      zones         = ["us-east-1a"]
     }
-
-    disk_size      = 20
-    instance_types = ["m6i.large"]
-  }
+  ]
 
   eks_tags = {
     CreatedBy = "mr-robot"

--- a/examples/eks-cluster-only/main.tf
+++ b/examples/eks-cluster-only/main.tf
@@ -41,7 +41,7 @@ module "eks_clickhouse" {
     }
 
     disk_size      = 20
-    instance_types = ["m5.large"]
+    instance_types = ["m6i.large"]
   }
 
   eks_tags = {

--- a/examples/eks-cluster-only/main.tf
+++ b/examples/eks-cluster-only/main.tf
@@ -33,16 +33,24 @@ module "eks_clickhouse" {
     "10.0.102.0/24",
     "10.0.103.0/24"
   ]
-  eks_node_pools_config = {
-    scaling_config = {
-      desired_size = 2
-      max_size     = 10
-      min_size     = 0
+  eks_node_pools = [
+    {
+      name          = "clickhouse"
+      instance_type = "m6i.large"
+      desired_size  = 0
+      max_size      = 10
+      min_size      = 0
+      zones         = ["us-east-1a", "us-east-1b", "us-east-1c"]
+    },
+    {
+      name          = "system"
+      instance_type = "t3.large"
+      desired_size  = 1
+      max_size      = 10
+      min_size      = 0
+      zones         = ["us-east-1a"]
     }
-
-    disk_size      = 20
-    instance_types = ["m6i.large"]
-  }
+  ]
 
   eks_tags = {
     CreatedBy = "mr-robot"

--- a/examples/public-loadbalancer/main.tf
+++ b/examples/public-loadbalancer/main.tf
@@ -36,16 +36,24 @@ module "eks_clickhouse" {
     "10.0.102.0/24",
     "10.0.103.0/24"
   ]
-  eks_node_pools_config = {
-    scaling_config = {
-      desired_size = 2
-      max_size     = 10
-      min_size     = 0
+  eks_node_pools = [
+    {
+      name          = "clickhouse"
+      instance_type = "m6i.large"
+      desired_size  = 0
+      max_size      = 10
+      min_size      = 0
+      zones         = ["us-east-1a", "us-east-1b", "us-east-1c"]
+    },
+    {
+      name          = "system"
+      instance_type = "t3.large"
+      desired_size  = 1
+      max_size      = 10
+      min_size      = 0
+      zones         = ["us-east-1a"]
     }
-
-    disk_size      = 20
-    instance_types = ["m6i.large"]
-  }
+  ]
 
   eks_tags = {
     CreatedBy = "mr-robot"

--- a/examples/public-loadbalancer/main.tf
+++ b/examples/public-loadbalancer/main.tf
@@ -44,7 +44,7 @@ module "eks_clickhouse" {
     }
 
     disk_size      = 20
-    instance_types = ["m5.large"]
+    instance_types = ["m6i.large"]
   }
 
   eks_tags = {

--- a/examples/public-subnets-only/main.tf
+++ b/examples/public-subnets-only/main.tf
@@ -29,16 +29,24 @@ module "eks_clickhouse" {
     "10.0.102.0/24",
     "10.0.103.0/24"
   ]
-  eks_node_pools_config = {
-    scaling_config = {
-      desired_size = 2
-      max_size     = 10
-      min_size     = 0
+  eks_node_pools = [
+    {
+      name          = "clickhouse"
+      instance_type = "m6i.large"
+      desired_size  = 0
+      max_size      = 10
+      min_size      = 0
+      zones         = ["us-east-1a", "us-east-1b", "us-east-1c"]
+    },
+    {
+      name          = "system"
+      instance_type = "t3.large"
+      desired_size  = 1
+      max_size      = 10
+      min_size      = 0
+      zones         = ["us-east-1a"]
     }
-
-    disk_size      = 20
-    instance_types = ["m6i.large"]
-  }
+  ]
 
   eks_tags = {
     CreatedBy = "mr-robot"

--- a/examples/public-subnets-only/main.tf
+++ b/examples/public-subnets-only/main.tf
@@ -37,7 +37,7 @@ module "eks_clickhouse" {
     }
 
     disk_size      = 20
-    instance_types = ["m5.large"]
+    instance_types = ["m6i.large"]
   }
 
   eks_tags = {

--- a/main.tf
+++ b/main.tf
@@ -37,7 +37,8 @@ module "eks_aws" {
   availability_zones  = var.eks_availability_zones
   cluster_version     = var.eks_cluster_version
   autoscaler_version  = var.eks_autoscaler_version
-  node_pools_config   = var.eks_node_pools_config
+  autoscaler_replicas = var.autoscaler_replicas
+  node_pools          = var.eks_node_pools
   tags                = var.eks_tags
   enable_nat_gateway  = var.eks_enable_nat_gateway
 }
@@ -60,7 +61,7 @@ module "clickhouse_cluster" {
   clickhouse_cluster_namespace           = var.clickhouse_cluster_namespace
   clickhouse_cluster_password            = var.clickhouse_cluster_password
   clickhouse_cluster_user                = var.clickhouse_cluster_user
-  clickhouse_cluster_instance_type       = var.eks_node_pools_config.instance_types[0]
+  clickhouse_cluster_instance_type       = var.eks_node_pools[0].instance_type
   clickhouse_cluster_enable_loadbalancer = var.clickhouse_cluster_enable_loadbalancer
 
   k8s_availability_zones            = var.eks_availability_zones

--- a/main.tf
+++ b/main.tf
@@ -25,6 +25,10 @@ provider "helm" {
   }
 }
 
+provider "aws" {
+  region = var.eks_region
+}
+
 module "eks_aws" {
   source = "./eks"
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -34,3 +34,7 @@ output "clickhouse_cluster_url" {
   description = "The public URL for the ClickHouse cluster"
   value       = length(module.clickhouse_cluster) > 0 ? module.clickhouse_cluster[0].clickhouse_cluster_url : ""
 }
+
+output "cluster_node_pools" {
+  value = module.eks_aws.cluster_node_pools
+}

--- a/variables.tf
+++ b/variables.tf
@@ -95,6 +95,18 @@ variable "eks_autoscaler_version" {
   default     = "1.29.2"
 }
 
+variable "eks_autoscaler_replicas" {
+  description = "Number of replicas for AWS Autoscaler"
+  type        = number
+  default     = 1
+}
+
+variable "autoscaler_replicas" {
+  description = "Autoscaler replicas"
+  type        = number
+  default     = 1
+}
+
 variable "eks_tags" {
   description = "A map of AWS tags"
   type        = map(string)
@@ -107,15 +119,18 @@ variable "eks_cidr" {
   default     = "10.0.0.0/16"
 }
 
-variable "eks_node_pools_config" {
+variable "eks_node_pools" {
   description = "Node pools configuration. The module will create a node pool for each combination of instance type and subnet. For example, if you have 3 subnets and 2 instance types, this module will create 6 different node pools."
 
-  type = object({
-    scaling_config = object({
-      desired_size = number
-      max_size     = number
-      min_size     = number
-    })
+  type = list(object({
+    name          = string
+    instance_type = string
+    ami_type      = optional(string)
+    disk_size     = optional(number)
+    desired_size  = number
+    max_size      = number
+    min_size      = number
+    zones         = optional(list(string))
 
     labels = optional(map(string))
     taints = optional(list(object({
@@ -123,24 +138,30 @@ variable "eks_node_pools_config" {
       value  = string
       effect = string
     })), [])
+  }))
 
-    disk_size      = number
-    instance_types = list(string)
-  })
-
-  default = {
-    scaling_config = {
-      desired_size = 2
-      max_size     = 10
-      min_size     = 0
+  default = [
+    {
+      name          = "clickhouse"
+      instance_type = "m6i.large"
+      ami_type      = "AL2_x86_64"
+      desired_size  = 0
+      disk_size     = 20
+      max_size      = 10
+      min_size      = 0
+      zones         = ["us-east-1a", "us-east-1b", "us-east-1c"]
+    },
+    {
+      name          = "system"
+      instance_type = "t3.large"
+      ami_type      = "AL2_x86_64"
+      disk_size     = 20
+      desired_size  = 1
+      max_size      = 10
+      min_size      = 0
+      zones         = ["us-east-1a", "us-east-1b", "us-east-1c"]
     }
-
-    labels = {}
-    taints = []
-
-    disk_size      = 20
-    instance_types = ["m5.large"]
-  }
+  ]
 }
 
 variable "eks_enable_nat_gateway" {

--- a/variables.tf
+++ b/variables.tf
@@ -159,7 +159,7 @@ variable "eks_node_pools" {
       desired_size  = 1
       max_size      = 10
       min_size      = 0
-      zones         = ["us-east-1a", "us-east-1b", "us-east-1c"]
+      zones         = ["us-east-1a"]
     }
   ]
 }


### PR DESCRIPTION
> 🚨 BREAKING CHANGES

This PR tries to bring more flexibility on how the node pools are defined:

- Replace `eks_node_pools` with `eks_node_pools_config`
- Now on `eks_node_pools` you can create individual groups with specific settings for instance type, escalation, zones, etc.
- All of these new values have defaults, you can use default node pools setup or even when setting up a custom node pool you can use default values for individual props as well (like `disk_size`)
- Not related but also adding a new property to customize autoscaler replicas `eks_autoscaler_replicas`

```hcl
  eks_node_pools = [
    {
      name          = "clickhouse"
      instance_type = "m6i.large"
      desired_size  = 0
      max_size      = 10
      min_size      = 0
      zones         = ["us-east-1a", "us-east-1b", "us-east-1c"]
    },
    {
      name          = "system"
      instance_type = "t3.large"
      desired_size  = 1
      max_size      = 10
      min_size      = 0
      zones         = ["us-east-1a"]
    }
  ]
```