### PR TITLE
Ensure the system pool creates a node in the first zone even when desired_size=0

### DIFF
--- a/eks/main.tf
+++ b/eks/main.tf
@@ -15,18 +15,26 @@ locals {
   # Generate all node pools possible combinations of subnets and node pools
   node_pool_combinations = flatten([
     for np in var.node_pools : [
-      for zone in(np.zones != null ? np.zones : keys(local.subnets_by_zone)) : [
+      for i, zone in(np.zones != null ? np.zones : keys(local.subnets_by_zone)) : [
         {
           name          = np.name != null ? np.name : np.instance_type
           subnet_id     = local.subnets_by_zone[zone]
           instance_type = np.instance_type
           labels        = np.labels
           taints        = np.taints
-          desired_size  = np.desired_size != null ? np.desired_size : local.node_pool_defaults.desired_size
-          max_size      = np.max_size != null ? np.max_size : local.node_pool_defaults.max_size
-          min_size      = np.min_size != null ? np.min_size : local.node_pool_defaults.min_size
-          disk_size     = np.disk_size != null ? np.disk_size : local.node_pool_defaults.disk_size
-          ami_type      = np.ami_type != null ? np.ami_type : local.node_pool_defaults.ami_type
+          desired_size = np.desired_size == null ? (
+            local.node_pool_defaults.desired_size
+            ) : (
+            np.name == "system" && i == 0 && np.desired_size == 0 ? (
+              local.node_pool_defaults.desired_size
+              ) : (
+              np.desired_size
+            )
+          )
+          max_size  = np.max_size != null ? np.max_size : local.node_pool_defaults.max_size
+          min_size  = np.min_size != null ? np.min_size : local.node_pool_defaults.min_size
+          disk_size = np.disk_size != null ? np.disk_size : local.node_pool_defaults.disk_size
+          ami_type  = np.ami_type != null ? np.ami_type : local.node_pool_defaults.ami_type
         }
       ]
     ]


### PR DESCRIPTION
This little hack makes it possible to bootstrap a cluster with only one node in the system node pool for cost efficiency, but allows the cluster autoscaler to provision system nodes in other zones when it's necessary using the following configuration:
```
eks_node_pools = [
    {
      name          = "clickhouse"
      instance_type = "m6i.large"
      desired_size  = 0
      max_size      = 10
      min_size      = 0
      zones         = ["${local.region}a", "${local.region}b", "${local.region}c"]
    },
    {
      name          = "system"
      instance_type = "t3.large"
      desired_size  = 0
      max_size      = 10
      min_size      = 0
      zones         = ["${local.region}a", "${local.region}b", "${local.region}c"]
    }
  ]
