### PR TITLE
feat: add default taints for clickhouse nodes

### DIFF
--- a/eks/variables.tf
+++ b/eks/variables.tf
@@ -128,6 +128,14 @@ variable "node_pools" {
       zones         = ["us-east-1a", "us-east-1b", "us-east-1c"]
     }
   ]
+
+  validation {
+    condition = alltrue([
+      for np in var.node_pools :
+      startswith(np.name, "clickhouse") || startswith(np.name, "system")
+    ])
+    error_message = "Each node pool name must start with either 'clickhouse' or 'system' prefix."
+  }
 }
 
 variable "public_access_cidrs" {

--- a/variables.tf
+++ b/variables.tf
@@ -162,6 +162,14 @@ variable "eks_node_pools" {
       zones         = ["us-east-1a"]
     }
   ]
+
+  validation {
+    condition = alltrue([
+      for np in var.eks_node_pools :
+      startswith(np.name, "clickhouse") || startswith(np.name, "system")
+    ])
+    error_message = "Each node pool name must start with either 'clickhouse' or 'system' prefix."
+  }
 }
 
 variable "eks_enable_nat_gateway" {


### PR DESCRIPTION
This input for `var.eks_node_pools`:

```hcl
eks_node_pools = [
  {
    name          = "clickhouse"
    instance_type = "m6i.large"
    desired_size  = 1
    max_size      = 10
    min_size      = 0
    zones         = ["us-east-1a", "us-east-1b", "us-east-1c"]
  },
  {
    name          = "system"
    instance_type = "t3.large"
    desired_size  = 1
    max_size      = 10
    min_size      = 0
    zones         = ["us-east-1a"]
  }
]
```

Will generate this output for EKS node groups:

```hcl
cluster_node_pools          = [
      + {
          + ami_type      = "AL2_x86_64"
          + desired_size  = 1
          + disk_size     = 20
          + instance_type = "m6i.large"
          + labels        = {
              + "altinity.cloud/created-by" = "terraform-aws-eks-clickhouse"
            }
          + max_size      = 10
          + min_size      = 0
          + name          = "clickhouse"
          + subnet_id     = (known after apply)
          + taints        = [
              + {
                  + effect = "NO_SCHEDULE"
                  + key    = "dedicated"
                  + value  = "clickhouse"
                },
            ]
        },
      + {
          + ami_type      = "AL2_x86_64"
          + desired_size  = 1
          + disk_size     = 20
          + instance_type = "m6i.large"
          + labels        = {
              + "altinity.cloud/created-by" = "terraform-aws-eks-clickhouse"
            }
          + max_size      = 10
          + min_size      = 0
          + name          = "clickhouse"
          + subnet_id     = (known after apply)
          + taints        = [
              + {
                  + effect = "NO_SCHEDULE"
                  + key    = "dedicated"
                  + value  = "clickhouse"
                },
            ]
        },
      + {
          + ami_type      = "AL2_x86_64"
          + desired_size  = 1
          + disk_size     = 20
          + instance_type = "m6i.large"
          + labels        = {
              + "altinity.cloud/created-by" = "terraform-aws-eks-clickhouse"
            }
          + max_size      = 10
          + min_size      = 0
          + name          = "clickhouse"
          + subnet_id     = (known after apply)
          + taints        = [
              + {
                  + effect = "NO_SCHEDULE"
                  + key    = "dedicated"
                  + value  = "clickhouse"
                },
            ]
        },
      + {
          + ami_type      = "AL2_x86_64"
          + desired_size  = 1
          + disk_size     = 20
          + instance_type = "t3.large"
          + labels        = {
              + "altinity.cloud/created-by" = "terraform-aws-eks-clickhouse"
            }
          + max_size      = 10
          + min_size      = 0
          + name          = "system"
          + subnet_id     = (known after apply)
          + taints        = []
        },
    ]
```