### PR TITLE
fix: replace deprecated kubernetes resources with v1 versions

### DIFF
--- a/clickhouse-cluster/load-balancer.tf
+++ b/clickhouse-cluster/load-balancer.tf
@@ -63,7 +63,7 @@ resource "null_resource" "wait_for_clickhouse" {
   }
 }
 
-data "kubernetes_service" "clickhouse_load_balancer" {
+data "kubernetes_service_v1" "clickhouse_load_balancer" {
   depends_on = [null_resource.wait_for_clickhouse]
   count      = var.clickhouse_cluster_enable_loadbalancer ? 1 : 0
 

--- a/clickhouse-cluster/outputs.tf
+++ b/clickhouse-cluster/outputs.tf
@@ -5,6 +5,6 @@ output "clickhouse_cluster_password" {
 }
 
 output "clickhouse_cluster_url" {
-  value       = var.clickhouse_cluster_enable_loadbalancer && length(data.kubernetes_service_v1.clickhouse_load_balancer) > 0 && length(data.kubernetes_service.clickhouse_load_balancer[*].status[*].load_balancer[*].ingress) > 0 ? data.kubernetes_service.clickhouse_load_balancer[0].status[0].load_balancer[0].ingress[0].hostname : "N/A"
+  value       = var.clickhouse_cluster_enable_loadbalancer && length(data.kubernetes_service_v1.clickhouse_load_balancer) > 0 && length(data.kubernetes_service_v1.clickhouse_load_balancer[*].status[*].load_balancer[*].ingress) > 0 ? data.kubernetes_service_v1.clickhouse_load_balancer[0].status[0].load_balancer[0].ingress[0].hostname : "N/A"
   description = "The public URL for the ClickHouse cluster"
 }

--- a/clickhouse-cluster/outputs.tf
+++ b/clickhouse-cluster/outputs.tf
@@ -5,6 +5,6 @@ output "clickhouse_cluster_password" {
 }
 
 output "clickhouse_cluster_url" {
-  value       = var.clickhouse_cluster_enable_loadbalancer && length(data.kubernetes_service.clickhouse_load_balancer) > 0 && length(data.kubernetes_service.clickhouse_load_balancer[*].status[*].load_balancer[*].ingress) > 0 ? data.kubernetes_service.clickhouse_load_balancer[0].status[0].load_balancer[0].ingress[0].hostname : "N/A"
+  value       = var.clickhouse_cluster_enable_loadbalancer && length(data.kubernetes_service_v1.clickhouse_load_balancer) > 0 && length(data.kubernetes_service.clickhouse_load_balancer[*].status[*].load_balancer[*].ingress) > 0 ? data.kubernetes_service.clickhouse_load_balancer[0].status[0].load_balancer[0].ingress[0].hostname : "N/A"
   description = "The public URL for the ClickHouse cluster"
 }

--- a/docs/ebs.md
+++ b/docs/ebs.md
@@ -12,7 +12,7 @@ This Terraform module configures the AWS Elastic Block Store (EBS) Container Sto
 - **`module.eks_blueprints_addons`**: Configures the AWS EBS CSI driver as an EKS managed addon via the EKS Blueprints Addons module. This simplifies management and ensures the driver is kept up-to-date with the latest releases and security patches.
 
 ### Kubernetes Storage Class
-- **`kubernetes_storage_class_vi.gp3-encrypted`**: Defines a storage class named `gp3-encrypted`, set as the default class for dynamic volume provisioning:
+- **`kubernetes_storage_class_v1.gp3-encrypted`**: Defines a storage class named `gp3-encrypted`, set as the default class for dynamic volume provisioning:
   - **Type**: `gp3` (latest generation general purpose SSD)
   - **Encryption**: Enabled by default
   - **Filesystem**: `ext4`

--- a/docs/ebs.md
+++ b/docs/ebs.md
@@ -12,7 +12,7 @@ This Terraform module configures the AWS Elastic Block Store (EBS) Container Sto
 - **`module.eks_blueprints_addons`**: Configures the AWS EBS CSI driver as an EKS managed addon via the EKS Blueprints Addons module. This simplifies management and ensures the driver is kept up-to-date with the latest releases and security patches.
 
 ### Kubernetes Storage Class
-- **`kubernetes_storage_class.gp3-encrypted`**: Defines a storage class named `gp3-encrypted`, set as the default class for dynamic volume provisioning:
+- **`kubernetes_storage_class_vi.gp3-encrypted`**: Defines a storage class named `gp3-encrypted`, set as the default class for dynamic volume provisioning:
   - **Type**: `gp3` (latest generation general purpose SSD)
   - **Encryption**: Enabled by default
   - **Filesystem**: `ext4`

--- a/eks/addons.tf
+++ b/eks/addons.tf
@@ -28,7 +28,7 @@ module "eks_blueprints_addons" {
   }
 }
 
-resource "kubernetes_storage_class" "gp3-encrypted" {
+resource "kubernetes_storage_class_v1" "gp3-encrypted" {
   depends_on = [module.eks_blueprints_addons]
 
   metadata {


### PR DESCRIPTION
Replaces deprecated Kubernetes resources:

- data "kubernetes_service" → data "kubernetes_service_v1"
- resource "kubernetes_storage_class" → resource "kubernetes_storage_class_v1"

Fixes Terraform deprecation warnings mentioned in issue #31.